### PR TITLE
Moodle 2.2 compatibility

### DIFF
--- a/build.php
+++ b/build.php
@@ -29,7 +29,8 @@ $grouping_name = trim(optional_param('groupingName', null, PARAM_TEXT));
 $inherit_grouping_name = optional_param('inheritGroupingName', 0, PARAM_INT);
 $nogrouping = optional_param('nogrouping', 0, PARAM_INT);
 
-$teams = optional_param('teams', array(), PARAM_RAW);
+$teams = optional_param_array('teams', array(), PARAM_RAW);
+$team_names = optional_param_array('teamnames', array(), PARAM_TEXT);
 
 if ($id) {
     if (! $cm = get_coursemodule_from_id('teambuilder', $id)) {
@@ -92,8 +93,10 @@ if(!is_null($action) && $action == "create-groups")
         }
     }
 
-    foreach($teams as $name => $team)
+    foreach($teams as $k => $teamstr)
     {
+		$name = $team_names[$k];
+		$team = explode(",",$teamstr);
         $oname = !$nogrouping && $inherit_grouping_name ? "$grouping_name $name" : $name;
         $groupdata = new stdClass();
         $groupdata->courseid = $course->id;

--- a/js/build.js
+++ b/js/build.js
@@ -799,12 +799,10 @@ function createGroups() {
 	{
 		var tn = teamNames[i];
 		var assign = teamAssignments[i];
-		for(j = 0; j < assign.length; j++)
-		{
-			var ta = assign[j];
-			var input = $('<input type="hidden" name="teams['+tn+'][]" value="'+ta+'" />')
-			form.append(input);
-		}
+		var tnInput = $('<input type="hidden" name="teamnames['+i+']" value="'+tn+'" />');
+		form.append(tnInput)
+		var input = $('<input type="hidden" name="teams['+i+']" value="'+assign.join(",")+'" />')
+		form.append(input);
 	}
 	
 	var action = $('<input type="hidden" name="action" value="create-groups" />');


### PR DESCRIPTION
Moodle 2.2 disallows optional_param taking an array, and disallows
arrays of arrays in parameters. This changes the teams array of arrays
submitted via POST when creating groups to two arrays, teams and
teamnames, with teams being an array of comma-separated user IDs rather
than an array of arrays of user IDs.
