### PR TITLE
Fix "none of" selecting participants who have not responded

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -217,7 +217,10 @@ function updateRunningCounter(criterion) {
 	ctr = 0;
 	for(i in students)
 	{
-//			s = students[i];
+    if(responses[i] === false)
+    { // don't count students with no response
+      continue;
+    }
 		if(studentMeetsCriterion(i,c))
 		{
 			ctr++;
@@ -491,6 +494,14 @@ function buildTeams()
 		rslt = /student-(\d+)/.exec(this.id);
 		assignedStudents[rslt[1]] = students[rslt[1]];
 	});
+  
+  //get rid of students with no responses
+  $.each(responses, function(k, v){
+    if (v === false) {
+      delete assignedStudents[k];
+      delete unassignedStudents[k];
+    }
+  });
 	
 	//initialise teamsPriority to all zeroes
 	teamsPriority = [];
@@ -693,6 +704,8 @@ function studentsMeetingCriterionGroup(students,criterionGroup)
 function studentMeetsCriterion(student,criterion)
 {
 	sr = responses[student]; //student responses
+  if(sr === false) 
+    return false; //students without a response cannot meet a criterion
 	
 	var ret; //return value
 	


### PR DESCRIPTION
When building teams, users have the option of having a team member who
selected none of the given answers. Currently this also includes
participants who did not respond to the questionnaire. This patch
prevents people who did not respond from being included as prospective
team members.
